### PR TITLE
Usb4java javax 1.2.1

### DIFF
--- a/src/main/java/org/usb4java/javax/AbstractIrpQueue.java
+++ b/src/main/java/org/usb4java/javax/AbstractIrpQueue.java
@@ -58,24 +58,26 @@ abstract class AbstractIrpQueue<T extends UsbIrp>
      * @param irp
      *            The control IRP to queue.
      */
-    public final synchronized void add(final T irp)
+    public final void add(final T irp)
     {
         this.irps.add(irp);
 
         // Start the queue processor if not already running.
         if (this.processor == null)
         {
-            this.processor = new Thread(new Runnable()
-            {
-                @Override
-                public void run()
-                {
-                    process();
+            synchronized(this) {
+                if (this.processor == null) {
+                    this.processor = new Thread(new Runnable() {
+                        @Override
+                        public void run() {
+                            process();
+                        }
+                    });
+                    this.processor.setDaemon(true);
+                    this.processor.setName("usb4java IRP Queue Processor");
+                    this.processor.start();
                 }
-            });
-            this.processor.setDaemon(true);
-            this.processor.setName("usb4java IRP Queue Processor");
-            this.processor.start();
+            }
         }
     }
 


### PR DESCRIPTION
Added synchronized blocks around IRP thread control. Without this, several IRP threads can end up being produced while under load in a multi-thread environment. The threads didnt really seem to compete, so they just quietly sat there idle...
