### PR TITLE
Use maxPacketSize of Interface 0 for the buffer in getUsbStringDescriptor and getLanguages

### DIFF
--- a/src/main/java/org/usb4java/javax/AbstractDevice.java
+++ b/src/main/java/org/usb4java/javax/AbstractDevice.java
@@ -507,7 +507,8 @@ abstract class AbstractDevice implements UsbDevice
         final short[] languages = getLanguages();
         final DeviceHandle handle = open();
         final short langId = languages.length == 0 ? 0 : languages[0];
-        final ByteBuffer data = ByteBuffer.allocateDirect(256);
+        final byte maxBufferSize = getUsbDeviceDescriptor().bMaxPacketSize0();
+        final ByteBuffer data = ByteBuffer.allocateDirect(maxBufferSize);
         final int result =
             LibUsb.getStringDescriptor(handle, index, langId, data);
         if (result < 0)
@@ -536,7 +537,8 @@ abstract class AbstractDevice implements UsbDevice
     private short[] getLanguages() throws UsbException
     {
         final DeviceHandle handle = open();
-        final ByteBuffer buffer = ByteBuffer.allocateDirect(256);
+        final byte maxBufferSize = getUsbDeviceDescriptor().bMaxPacketSize0();
+        final ByteBuffer buffer = ByteBuffer.allocateDirect(maxBufferSize);
         final int result = LibUsb.getDescriptor(handle, LibUsb.DT_STRING,
             (byte) 0, buffer);
         if (result < 0)


### PR DESCRIPTION
We can use max buffer size obtained from `descriptor.bMaxPacketSize0()` instead of 256 in these methods because internally they call controlTransfer on interface #0.
This fixes #3 without manipulations with dirvers. Some devices require to use a buffer of size bMaxPacketSize0 only for control transfer.